### PR TITLE
Add liveness probes for sbc-ib-ob feature server deployments

### DIFF
--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -95,6 +95,14 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh", "-c", "/opt/app/bin/k8s-pre-stop-hook.js"]
+          # livenessProbe:
+          #   exec:
+          #     command:
+          #       - /bin/sh
+          #       - /opt/app/liveness.sh
+          #   initialDelaySeconds: 15
+          #   periodSeconds: 60
+          #   failureThreshold: 2
           volumeMounts:
             - mountPath: /tmp 
               name: temp-audio-volume

--- a/templates/sbc-inbound-deployment.yaml
+++ b/templates/sbc-inbound-deployment.yaml
@@ -40,6 +40,14 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh", "-c", "/opt/app/bin/k8s-pre-stop-hook.js"]
+          # livenessProbe:
+          #   exec:
+          #     command:
+          #       - /bin/sh
+          #       - /opt/app/liveness.sh
+          #   initialDelaySeconds: 15
+          #   periodSeconds: 60
+          #   failureThreshold: 2
           ports:
             - name: dtmf
               containerPort: 22224

--- a/templates/sbc-outbound-deployment.yaml
+++ b/templates/sbc-outbound-deployment.yaml
@@ -40,6 +40,14 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh", "-c", "/opt/app/bin/k8s-pre-stop-hook.js"]
+          # livenessProbe:
+          #   exec:
+          #     command:
+          #       - /bin/sh
+          #       - /opt/app/liveness.sh
+          #   initialDelaySeconds: 15
+          #   periodSeconds: 60
+          #   failureThreshold: 2
           ports:
             - name: dtmf
               containerPort: 22225


### PR DESCRIPTION
Scripts are commented out for now and tightly coupled with their implementation PRs.

(also, please not it liveness.sh scripts might need a chmod u+x for kubernetes user to be able to invoke them)