### PR TITLE
use values for secrets and also for api protocol

### DIFF
--- a/charts/db/templates/secrets.yaml
+++ b/charts/db/templates/secrets.yaml
@@ -8,4 +8,4 @@ metadata:
 type: Opaque
 data:
     # use 32 bytes of random value, hex
-    MYSQL_PASSWORD: amFtYm9uZXM=
+    MYSQL_PASSWORD: {{ .Values.mysql.secret }}

--- a/charts/db/values.yaml
+++ b/charts/db/values.yaml
@@ -5,7 +5,7 @@ mysql:
   database: jambones
   user: jambones 
   storage: 10Gi
-
+  secret: amFtYm9uZXM=
 # redis configuration used by Node.js app that need to connect
 redis: 
   image: redis:alpine

--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -49,11 +49,16 @@ spec:
             - name: CLOUD 
               value: {{ required "cloud provider name"  .Values.cloud | quote }}
             - name: IMDSv2 
-              value: {{ .Values.awsUseIMDSv2 }}
+              value: {{ .Values.awsUseIMDSv2 | quote }}
             - name: SOFIA_SEARCH_DOMAINS
               value: "1"
             - name: SOFIA_SRES_NO_CACHE
               value: "1"
+            - name: DRACHTIO_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: jambonz-secrets
+                  key: DRACHTIO_SECRET
           lifecycle:
             preStop:
               exec:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -7,11 +7,6 @@ metadata:
 {{ include "common.labels" . | indent 4 }}
 type: Opaque
 data:
-    # use 32 bytes of random value, hex
     MYSQL_PASSWORD: {{ .Values.db.mysql.secret }}
     DRACHTIO_SECRET: {{ .Values.drachtio.secret }}
     JWT_SECRET: {{ .Values.jwt.secret }}
-    # use 32 bytes of random value, hex
-    MYSQL_PASSWORD: amFtYm9uZXM=
-    DRACHTIO_SECRET: Y3ltcnU=
-    JWT_SECRET: Rz11JS05NyNUZmZZZg==

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -8,6 +8,10 @@ metadata:
 type: Opaque
 data:
     # use 32 bytes of random value, hex
+    MYSQL_PASSWORD: {{ .Values.db.mysql.secret }}
+    DRACHTIO_SECRET: {{ .Values.drachtio.secret }}
+    JWT_SECRET: {{ .Values.jwt.secret }}
+    # use 32 bytes of random value, hex
     MYSQL_PASSWORD: amFtYm9uZXM=
     DRACHTIO_SECRET: Y3ltcnU=
     JWT_SECRET: Rz11JS05NyNUZmZZZg==

--- a/templates/webapp-deployment.yaml
+++ b/templates/webapp-deployment.yaml
@@ -23,12 +23,12 @@ spec:
             - name: REACT_APP_API_BASE_URL
               {{- if .Values.global.kong.enabled }}
               {{- if .Values.global.kong.useHostnames }}            
-              value: http://{{ .Values.api.hostname }}/v1
+              value: {{ default "http" .Values.api.protocol }}://{{ .Values.api.hostname }}/v1
               {{else}}
-              value: http://{{ .Values.api.hostname }}/webapp/v1
+              value: {{ default "http" .Values.api.protocol }}://{{ .Values.api.hostname }}/webapp/v1
               {{- end}}
               {{else}}
-              value: http://{{ .Values.api.hostname }}/v1
+              value: {{ default "http" .Values.api.protocol }}://{{ .Values.api.hostname }}/v1
               {{- end}}
             - name: GF_SERVER_ROOT_URL
               value: "/grafana"

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,10 @@
 global:
   # if defined, create and/or reference db and monitoring services in the specified namespace;
   # otherwise they create and/or referenced them in whatever the .Release namespace is
-  dbNamespace: 
-  monitoringNamespace:
+  db:
+    namespace: 
+  monitoring:
+    namespace:
   kong:
     enabled: false
     useHostnames: true 
@@ -10,6 +12,8 @@ global:
 db: 
   # if true, create the db subchart
   enabled: true
+  mysql: 
+    secret: amFtYm9uZXM=
 monitoring: 
   # if true, create the monitoring subchart
   enabled: true 
@@ -19,6 +23,9 @@ cloud:
 
 # set this to "1" if you are deploying on AWS and you are using IMDSv2
 awsUseIMDSv2:
+
+jwt:
+  secret: Rz11JS05NyNUZmZZZg==
 
 # basic information that applies to all jambonz Node.js app
 jambonz: 
@@ -71,6 +78,7 @@ drachtio:
   host: "127.0.0.1"
   port: "9022"
   homerId: "10"
+  secret: Y3ltcnU=
 
 # freeswitch configuration
 freeswitch: 
@@ -98,6 +106,9 @@ api:
   httpPort: "3000"
   # (required) hostname for the jambonz port ingress
   hostname:
+  # defaults to http, if you have tls enabled change to https 
+  # otherwise web to api connection will fail
+  protocol:
 
 # jambonz-webapp configuration
 webapp: 


### PR DESCRIPTION
This PR removes the hardcoded secrets and adds them to the values instead. 

Also we can now set the protocol used for connecting jambonz-webapp to jambonz-api. This is required, since if we deploy both with an ingress using TLS, we cannot connect from https to http protocol because this will be blocked by the browser.