### PR TITLE
Feature/make replica count configurable

### DIFF
--- a/templates/api-server-deployment.yaml
+++ b/templates/api-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   name: api-server
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: 1
+  replicas: {{ default 1 .Values.api.replicas }}
   selector:
     matchLabels:
       app: api-server

--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
 spec:
+  replicas: {{ default 1 .Values.featureServer.replicas }}
   selector:
     matchLabels:
       app: feature-server

--- a/templates/sbc-call-router-deployment.yaml
+++ b/templates/sbc-call-router-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ include "common.labels" . | indent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  replicas: {{ default 1 .Values.sbcCallRouter.replicas }}
   selector:
     matchLabels:
       app: sbc-call-router

--- a/templates/sbc-inbound-deployment.yaml
+++ b/templates/sbc-inbound-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ include "common.labels" . | indent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  replicas: {{ default 1 .Values.sbcInbound.replicas }}
   selector:
     matchLabels:
       app: sbc-inbound

--- a/templates/sbc-outbound-deployment.yaml
+++ b/templates/sbc-outbound-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ include "common.labels" . | indent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  replicas: {{ default 1 .Values.sbcOutbound.replicas }}
   selector:
     matchLabels:
       app: sbc-outbound

--- a/templates/sbc-register-deployment.yaml
+++ b/templates/sbc-register-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ include "common.labels" . | indent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  replicas: {{ default 1 .Values.sbcRegistrar.replicas }}
   selector:
     matchLabels:
       app: sbc-register

--- a/templates/webapp-deployment.yaml
+++ b/templates/webapp-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   name: webapp
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.webapp.replicas}}
+  replicas: {{ default 1 .Values.webapp.replicas}}
   selector:
     matchLabels:
       app: webapp

--- a/templates/webapp-deployment.yaml
+++ b/templates/webapp-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   name: webapp
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.webapp.replicas}}
   selector:
     matchLabels:
       app: webapp

--- a/values.yaml
+++ b/values.yaml
@@ -104,6 +104,7 @@ api:
   image: jambonz/api-server:latest
   imagePullPolicy: Always
   httpPort: "3000"
+  replicas: 1
   # (required) hostname for the jambonz port ingress
   hostname:
   # defaults to http, if you have tls enabled change to https 
@@ -114,6 +115,7 @@ api:
 webapp: 
   image: jambonz/webapp:latest
   imagePullPolicy: Always
+  replicas: 1
   
   # (required) hostname for the jambonz port ingress
   hostname: 
@@ -133,24 +135,28 @@ sbcInbound:
   image: jambonz/sbc-inbound:latest
   imagePullPolicy: Always
   drachtioPort: "4000"
+  replicas: 1
 
 # sbc-outbound configuration
 sbcOutbound: 
   image: jambonz/sbc-outbound:latest
   imagePullPolicy: Always
   drachtioPort: "4000"
+  replicas: 1
 
 # sbc-registrar configuration
 sbcRegistrar: 
   image: jambonz/sbc-registrar:latest
   imagePullPolicy: Always
   drachtioPort: "4000"
+  replicas: 1
 
 # sbc-call-router configuration
 sbcCallRouter: 
   image: jambonz/sbc-call-router:latest
   imagePullPolicy: Always
   httpPort: "3000"
+  replicas: 1
 
 # feature-server configuration
 featureServer: 
@@ -160,6 +166,7 @@ featureServer:
   drachtioConnection: "127.0.0.1:9022:cymru"
   freeswitchConnection: "127.0.0.1:8021:JambonzR0ck$"
   awsRegion: us-west-1
+  replicas: 1
 
 # sbc-sip configuration
 sbcSip: 


### PR DESCRIPTION
This PR allows configuration of a custom number of replicas which is useful if we need to meet high availability requirements and need to have 2 or more pods of each SIP processing service to ensure we have not a full downtime if one pod dies.