### PR TITLE
Added support for custom user and password for monitoring's postgres database

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ helm uninstall -n <namespace> <release-name>
 |mysql.user|mysql user|"jambones"|
 |mysql.storage|amount of storage to allocate for mysql database|"10Gi"|
 |mysql.rootSecret|if set, use it for the root password||
+|monitoring.postgres.user|postgres user as base64|"cm9vdA=="|
+|monitoring.postgres.secret|postgres password as base64|"aG9tZXJTZXZlbg=="|
 |redis.image|redis image|redis:alpine|
 |redis.host|redis service name|"redis"|
 |redis.port|redis listening port|"6379"|

--- a/charts/monitoring/templates/heplify-server-configmap.yaml
+++ b/charts/monitoring/templates/heplify-server-configmap.yaml
@@ -25,8 +25,8 @@ data:
     DBShema               = "homer7"
     DBDriver              = "postgres"
     DBAddr                = "postgres:5432"
-    DBUser                = "root"
-    DBPass                = "homerSeven"
+    DBUser                = {{ .Values.postgres.user | b64dec | quote }}
+    DBPass                = {{ .Values.postgres.secret | b64dec | quote }}
     DBDataTable           = "homer_data"
     DBConfTable           = "homer_config"
     DBBulk                = 200

--- a/charts/monitoring/templates/postgres-statefulset.yaml
+++ b/charts/monitoring/templates/postgres-statefulset.yaml
@@ -27,9 +27,12 @@ spec:
           name: postgres
           env:
             - name: POSTGRES_PASSWORD
-              value: homerSeven
+              valueFrom:
+                secretKeyRef:
+                  name: secrets
+                  key: POSTGRES_PASSWORD
             - name: POSTGRES_USER
-              value: root
+              value: {{ .Values.postgres.user | b64dec | quote }}
           ports:
             - containerPort: 5432
           resources: {}

--- a/charts/monitoring/templates/secrets.yaml
+++ b/charts/monitoring/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secrets
+  namespace: {{ dig "global" "monitoring" "namespace" .Release.Namespace (.Values | merge (dict)) | quote }}
+  labels:
+{{ include "common.labels" . | indent 4 }}
+type: Opaque
+data:
+    # use 32 bytes of random value, hex
+    POSTGRES_PASSWORD: {{ .Values.postgres.secret }}

--- a/charts/monitoring/templates/webapp-configmap.yaml
+++ b/charts/monitoring/templates/webapp-configmap.yaml
@@ -21,8 +21,8 @@ data:
         "keepalive": true,
         "name": "homer_config",
         "node": "LocalConfig",
-        "pass": "homerSeven",
-        "user": "root"
+        "pass": {{ .Values.postgres.secret | b64dec | quote }},
+        "user": {{ .Values.postgres.user | b64dec | quote }}
       },
       "database_data": {
         "localnode": {
@@ -31,8 +31,8 @@ data:
           "keepalive": true,
           "name": "homer_data",
           "node": "LocalNode",
-          "pass": "homerSeven",
-          "user": "root"
+          "pass": {{ .Values.postgres.secret | b64dec | quote }},
+          "user": {{ .Values.postgres.user | b64dec | quote }}
         }
       },
       "decoder_shark": {

--- a/charts/monitoring/templates/webapp-deployment.yaml
+++ b/charts/monitoring/templates/webapp-deployment.yaml
@@ -30,9 +30,12 @@ spec:
             - name: DB_HOST
               value: postgres
             - name: DB_USER
-              value: {{ .Values.postgres.user | quote }}
+              value: {{ .Values.postgres.user | b64dec | quote }}
             - name: DB_PASS
-              value: {{ .Values.postgres.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: secrets
+                  key: POSTGRES_PASSWORD
           volumeMounts:
             - mountPath: /usr/local/homer/etc/webapp_config.json
               name: webapp-conf

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -17,6 +17,8 @@ homer:
   hostname:
 postgres: 
   image: postgres:11-alpine
+  user: cm9vdA==
+  secret: aG9tZXJTZXZlbg==
   storage: 30Gi 
 telegraf: 
   image: telegraf:1.19

--- a/values.yaml
+++ b/values.yaml
@@ -30,7 +30,9 @@ db:
     secret: amFtYm9uZXM=
 monitoring: 
   # if true, create the monitoring subchart
-  enabled: true 
+  enabled: true
+  postgres: 
+    secret: amFtYm9uZXM=
 
 # (required) name of cloud provider: azure, aws, digitalocean, gcp, or none 
 cloud:


### PR DESCRIPTION
PostgreSQL database is not customizable, this PR will add support for changing the _user_ and _password_ for the database.

Note: The value for `mysql.secret` and `jwt.secret` must be set as a Base64 encoded string which I believe should not be the case as it only matters for the secret creation and the string could be encoded there. I used the same logic for the `postgres.user` and `postgres.secret` but it requires to decode it on other files. But changing that makes it a breaking change.