### PR TITLE
Quote the nodeSelector value for SIP and RTP DaemonSet

### DIFF
--- a/templates/sbc-rtp-daemonset.yaml
+++ b/templates/sbc-rtp-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
         app: jambonz-sbc-rtp
     spec:
       nodeSelector:
-        {{ .Values.sbc.rtp.nodeSelector.label }}: {{.Values.sbc.rtp.nodeSelector.value }}
+        {{ .Values.sbc.rtp.nodeSelector.label }}: {{.Values.sbc.rtp.nodeSelector.value | quote }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       tolerations:

--- a/templates/sbc-sip-daemonset.yaml
+++ b/templates/sbc-sip-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
         app: jambonz-sbc-sip
     spec:
       nodeSelector:
-        {{ .Values.sbc.sip.nodeSelector.label }}: {{.Values.sbc.sip.nodeSelector.value }}
+        {{ .Values.sbc.sip.nodeSelector.label }}: {{.Values.sbc.sip.nodeSelector.value | quote }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       tolerations:


### PR DESCRIPTION
When the nodeSelector label value is a boolean (`true` or `false`) the value transformed should be quoted.

Values example:
``` yml
sbc: 
  sip: 
    nodeSelector: 
      label: sip
      value: "true"
    toleration: sip
  rtp: 
    nodeSelector: 
      label: sip
      value: "true"
    toleration: sip
```