### PR TITLE
Added Recordings support for SBC-RTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,47 @@ useHostnames set to false will us the Kong IP address with prefixes.
 ```
 
 
+## Enable Call Recording
+
+To enable the recording of calls, we need an image of `jambonz/rtpengine` with the `libpcap-dev` package installed.
+
+### Generate a new image
+
+If none is available, then create one with a Dockerfile like so:
+
+``` Dockerfile
+FROM jambonz/rtpengine:0.1.3 as base
+
+RUN touch /var/lib/dpkg/status
+RUN mkdir /var/lib/dpkg/updates
+RUN mkdir /var/lib/dpkg/info
+RUN apt-get update
+RUN apt-get --assume-yes install libpcap-dev
+```
+
+### Configurations
+
+The following parameters are available to configure:
+
+|Name|Description|Default Value|
+|----|-----------|-----|
+|global.recordings.enabled|Enable the recordings on rtpengine|`false`|
+|rtpengine.recordings.pvc|PVC for the recordings|`recordings-shared-volume`|
+|rtpengine.recordings.dir|Mounted Directory in the pod for storing the recordings|`/recordings`|
+|rtpengine.recordings.method|Method for recording|`pcap`|
+
+Update `values.yaml` and set `global.recordings.enabled` to `true` to use the recordings. Ensure that the PVC is in the same namespace as the `jambonz-sbc-rtp` (defaults to `jambonz`).
+
+``` yaml
+global:
+  recordings:
+    enabled: true
+
+rtpengine:
+  image: # change the image of rtpengine to use one with the libpcap-dev package
+```
+
+
 ## Uninstalling the chart
 
 ```bash
@@ -168,6 +209,7 @@ helm uninstall -n <namespace> <release-name>
 |----|-----------|-----|
 |db.enabled|if true, install the db sub-chart|true|
 |monitoring.enabled|if true, install the monitoring sub-chart|true|
+|global.recordings.enabled|Enable call audio recordings on SBC-RTP|`false`|
 |cloud|(required) name of cloud provider, must be one of azure, aws, digitalocean, gcp, or none|""|
 |jambonz.clusterId|a short identifier for the cluster|""|
 |sbc.sip.nodeSelector.label|label name used to select sip node pool|"voip-environment"|
@@ -188,6 +230,9 @@ helm uninstall -n <namespace> <release-name>
 |rtpengine.dtmfLogPort|udp port that rtpengine sends dtmf events to|"22223"|
 |rtpengine.logLevel|rtpengine log level (1-7)|"5"|
 |rtpengine.homerId|id to apply to HEP traffic sent to homer from rtpengine|"11"|
+|rtpengine.recordings.pvc|PVC for the recordings|`recordings-shared-volume`|
+|rtpengine.recordings.dir|Mounted Directory in the pod for storing the recordings|`/recordings`|
+|rtpengine.recordings.method|Method for recording|`pcap`|
 |drachtio.image|drachtio image|drachtio/drachtio-server:latest|
 |drachtio.imagePullPolicy|drachtio image pull policy|"Always"|
 |drachtio.host|host of drachtio server|"127.0.0.1"|

--- a/templates/sbc-rtp-daemonset.yaml
+++ b/templates/sbc-rtp-daemonset.yaml
@@ -74,6 +74,12 @@ spec:
             - {{ .Values.rtpengine.homerId | quote }}
             - --log-level
             - {{ default 5 .Values.rtpengine.loglevel | quote }}
+            {{- if .Values.global.recordings.enabled }}
+            - --recording-method
+            - {{ .Values.rtpengine.recordings.method }}
+            - --recording-dir
+            - {{ .Values.rtpengine.recordings.dir | quote }}
+            {{- end }}
           env:
             - name: CLOUD 
               value: {{ required "cloud provider name" .Values.cloud | quote }}
@@ -84,7 +90,18 @@ spec:
                 secretKeyRef:
                   name: jambonz-secrets
                   key: DRACHTIO_SECRET
+          {{- if .Values.global.recordings.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.rtpengine.recordings.dir | quote }}
+              name: recordings
+          {{- end }}
           ports:
             - containerPort: 22222
               protocol: TCP
+      {{- if .Values.global.recordings.enabled }}
+      volumes:
+      - name: recordings
+        persistentVolumeClaim:
+          claimName: {{ .Values.rtpengine.recordings.pvc | quote }}
+      {{- end }}
       restartPolicy: Always

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,8 @@ global:
   kong:
     enabled: false
     useHostnames: true 
+  recordings:
+    enabled: false
 
 db: 
   # if true, create the db subchart
@@ -70,6 +72,11 @@ rtpengine:
   dtmfLogPort:  "22223"
   loglevel: "5"
   homerId: "11"
+  # used when global.recordings.enabled is true
+  recordings:
+    pvc: recordings-shared-volume
+    dir: /recordings
+    method: pcap
 
 # used by sidecar apps in sbc-sip and feature-server to connect locally to drachtio server
 drachtio: 


### PR DESCRIPTION
With this PR, the SBC-RTP DaemonSet will have the ability to record call audio.

It is required to have an image of `jambonz/rtpengine` with `libpcap-dev` installed and provide a `PersistentVolumeClaim`.

This feature is disabled by default.