### PR TITLE
Added SSL certificates to SBC-SIP in order to enable WSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,49 +311,17 @@ To obtain certificates, you just need to create resources of type [Certificate](
 ```
 As soon as you apply this CRD, you will have a new CertificateRequest created and a secret (drachtio-certs) created in jambonz  namespace.
 
-### Use your certs 
+### Use your certs
 
-To use the created certificates on drachtio server, you just have to mount *drachtio-certs* secret as volume on your Pod.
-In created secret (drachtio-certs) you will have two keys:
-```
-    - tls.key: base64 encoded private key
-    - tls.crt: base64 encoded full certs chain. 
-```
-
-You also need to choose a port to listen on for sip over wss.  In the example below, we are using port 8443.  
-
-> Note: you must be running drachtio server version 0.8.17-rc1 or later for support of the WSS_SIP env variable.
-
-Your updated sbc-sip-daemonset yaml should look something like this: 
+To use the created certificates on drachtio server, set the config `sbc.sip.ssl.enabled` to `true`:
 
 ```yaml
-      spec:
-          template: 
-              spec: 
-                  volumes:
-                      - name: drachtio-certs
-                        secret:
-                          secretName: drachtio-certs
-                          items:
-                            - key: tls.crt
-                              path: tls.crt
-                            - key: tls.key
-                              path: tls.key
-                          defaultMode: 420
-                  containers:
-                      - name: drachtio
-                        ...
-                        volumeMounts:
-                        - name: drachtio-certs
-                          mountPath: /etc/letsencrypt/
-                        env:
-                          - name: DRACHTIO_TLS_CERT_FILE
-                            value: /etc/letsencrypt/tls.crt
-                          - name: DRACHTIO_TLS_KEY_FILE
-                            value: /etc/letsencrypt/tls.key
-                          - name: WSS_PORT
-                            value: "8443"
-                          ...
+sbc:
+  sip:
+    ssl:
+      enabled: true
 ```
 
-This will cause drachtio to add a listener for sip over wss on port 8443 and use the provided TLS certificate and key to authenticate requests. 
+This will cause drachtio to add a listener for sip over wss on port 8443 and use the provided TLS certificate and key to authenticate requests.
+
+> Note: you must be running drachtio server version 0.8.17-rc1 or later for support of the WSS_SIP env variable.

--- a/templates/sbc-sip-daemonset.yaml
+++ b/templates/sbc-sip-daemonset.yaml
@@ -79,6 +79,14 @@ spec:
               value: {{ required "cloud provider name" .Values.cloud | quote }}
             - name: IMDSv2 
               value: {{ .Values.awsUseIMDSv2 | quote }}
+            {{- if .Values.sbc.sip.ssl.enabled }}
+            - name: DRACHTIO_TLS_CERT_FILE
+              value: /etc/ssl/tls.crt
+            - name: DRACHTIO_TLS_KEY_FILE
+              value: /etc/ssl/tls.key
+            - name: WSS_PORT
+              value: "8443"
+            {{- end }}
           ports:
             - containerPort: 9022
               protocol: TCP
@@ -86,11 +94,19 @@ spec:
               protocol: UDP
             - containerPort: 5060
               protocol: TCP
+            {{- if .Values.sbc.sip.ssl.enabled }}
+            - containerPort: 8443
+              protocol: TCP
+            {{- end }}
           resources: {}
           volumeMounts:
             - mountPath: /etc/drachtio.conf.xml
               name: jambonz-sbc-sip-conf
               subPath: drachtio.conf.xml
+            {{- if .Values.sbc.sip.ssl.enabled }}
+            - mountPath: /etc/ssl/
+              name: drachtio-certs
+            {{- end }}
         - name: sbc-options-handler
           image: {{ .Values.sbcOptionsHandler.image }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.sbcOptionsHandler.imagePullPolicy }} 
@@ -171,3 +187,13 @@ spec:
           items:
           - key: drachtio.conf.xml
             path: drachtio.conf.xml
+      {{- if .Values.sbc.sip.ssl.enabled }}
+      - name: drachtio-certs
+        secret:
+          secretName: drachtio-certs
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+      {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -48,6 +48,8 @@ sbc:
       label: voip-environment 
       value: sip
     toleration: sip
+    ssl:
+      enabled: false
   rtp: 
     nodeSelector: 
       label: voip-environment 


### PR DESCRIPTION
The README suggests to edit the chart to change the SBC-SIP DaemonSet to enable WSS. It should be baked in the chart and be enabled by a config.