### PR TITLE
SBC-RTP extra containers and StatefulSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ helm uninstall -n <namespace> <release-name>
 |sbc.rtp.nodeSelector.label|label name used to select sip node pool|"voip-environment"|
 |sbc.rtp.nodeSelector.value|label value used to select sip node pool|"rtp"|
 |sbc.rtp.toleration|taint assigned to sip node pool|"rtp"|
+|sbc.rtp.extraVolumes|list of volumes to add to the sbc-rtp definition of volumes||
+|sbc.rtp.extraInitContainers|list of initContainers to add to the sbc-rtp definition of initContainers||
+|sbc.rtp.extraContainers|list of sidecars to add to the sbc-rtp definition of containers||
+|sbc.rtp.statefulset.enabled|use a StatefulSet instead of DaemonSet for the sbc-rtp|`false`|
+|sbc.rtp.statefulset.replicas|number of replicas for the StatefulSet|`1`|
 |stats.enabled|if set, jambonz apps write stats to telegraf|"1"|
 |stats.host|telegraf service name|"telegraf"|
 |stats.port|telegraf service listening port|"8125"|
@@ -233,6 +238,7 @@ helm uninstall -n <namespace> <release-name>
 |rtpengine.recordings.pvc|PVC for the recordings|`recordings-shared-volume`|
 |rtpengine.recordings.dir|Mounted Directory in the pod for storing the recordings|`/recordings`|
 |rtpengine.recordings.method|Method for recording|`pcap`|
+|rtpengine.recordings.storage|Amount of storage for the recordings volume|`10Gi`|
 |drachtio.image|drachtio image|drachtio/drachtio-server:latest|
 |drachtio.imagePullPolicy|drachtio image pull policy|"Always"|
 |drachtio.host|host of drachtio server|"127.0.0.1"|

--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ helm uninstall -n <namespace> <release-name>
 |sbc.rtp.nodeSelector.label|label name used to select sip node pool|"voip-environment"|
 |sbc.rtp.nodeSelector.value|label value used to select sip node pool|"rtp"|
 |sbc.rtp.toleration|taint assigned to sip node pool|"rtp"|
-|sbc.rtp.extraVolumes|list of volumes to add to the sbc-rtp definition of volumes||
 |sbc.rtp.extraInitContainers|list of initContainers to add to the sbc-rtp definition of initContainers||
 |sbc.rtp.extraContainers|list of sidecars to add to the sbc-rtp definition of containers||
+|sbc.rtp.extraVolumes|list of volumes to add to the sbc-rtp definition of volumes||
 |sbc.rtp.statefulset.enabled|use a StatefulSet instead of DaemonSet for the sbc-rtp|`false`|
 |sbc.rtp.statefulset.replicas|number of replicas for the StatefulSet|`1`|
 |stats.enabled|if set, jambonz apps write stats to telegraf|"1"|
@@ -328,3 +328,55 @@ sbc:
 This will cause drachtio to add a listener for sip over wss on port 8443 and use the provided TLS certificate and key to authenticate requests.
 
 > Note: you must be running drachtio server version 0.8.17-rc1 or later for support of the WSS_SIP env variable.
+
+### Add extra containers or volumes to the SBC-RTP
+
+It may be required to do some processing on the data produced by the RTP service, like the recordings. For these scenarios, another container needs to run along the rtp and share a volume or a secret. Add the following configurations to your yaml file like you would populate a kubernetes deployment:
+
+```yaml
+sbc:
+  rtp:
+    #nodeSelector: 
+    #  label: rtp
+    #  value: "true"
+    #toleration: rtp
+    extraInitContainers:
+    - name: init-processor
+      image: my-service/init-processor:v1.0.0
+    extraContainers:
+    - name: recordings-processor
+      env:
+      - name: SERVER_PORT
+        value: "8080"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /app/secrets/gcp.serviceaccount.json
+      image: my-service/recordings-processor:v2.0.0
+      ports:
+      - containerPort: 8080
+        hostPort: 8080
+        protocol: TCP
+      resources:
+        requests:
+          cpu: 50m
+          memory: 300Mi
+      volumeMounts:
+      - mountPath: /app/secrets
+        mountPropagation: None
+        name: secrets-gcp
+        readOnly: true
+      - mountPath: /usr/src/app/cache
+        mountPropagation: None
+        name: cache
+      - mountPath: /recordings # if enabled with global.recordings.enabled
+        name: recordings
+    - name: another-processor
+      image: my-service/another-processor:v3.0.0
+    extraVolumes:
+    - name: secrets-gcp
+      secret:
+        defaultMode: 420
+        optional: false
+        secretName: gcp-secret
+    - emptyDir: {}
+      name: cache
+```

--- a/templates/sbc-rtp-daemonset.yaml
+++ b/templates/sbc-rtp-daemonset.yaml
@@ -26,6 +26,10 @@ spec:
         - key: {{ .Values.sbc.rtp.toleration | quote }}
           operator: "Exists"
           effect: "NoSchedule"
+      volumes:
+{{- if .Values.sbc.rtp.extraVolumes }}
+{{ toYaml .Values.sbc.rtp.extraVolumes | default "" | nindent 8 }}
+{{- end }}
       initContainers:
         - image: kanisterio/mysql-sidecar:0.40.0
           name: db-create-wait
@@ -43,6 +47,9 @@ spec:
                 secretKeyRef:
                   name: jambonz-secrets
                   key: MYSQL_PASSWORD
+{{- if .Values.sbc.rtp.extraInitContainers }}
+{{ toYaml .Values.sbc.rtp.extraInitContainers | default "" | nindent 8 }}
+{{- end }}
       containers:
         - name: rtpengine-sidecar
           image: {{ .Values.rtpengine.sidecarImage }}
@@ -99,6 +106,9 @@ spec:
           ports:
             - containerPort: 22222
               protocol: TCP
+{{- if .Values.sbc.rtp.extraContainers }}
+{{ toYaml .Values.sbc.rtp.extraContainers | default "" | nindent 8 }}
+{{- end }}
       {{- if .Values.global.recordings.enabled }}
       volumes:
       - name: recordings

--- a/templates/sbc-rtp-statefulset.yaml
+++ b/templates/sbc-rtp-statefulset.yaml
@@ -28,6 +28,10 @@ spec:
         - key: {{ .Values.sbc.rtp.toleration | quote }}
           operator: "Exists"
           effect: "NoSchedule"
+      volumes:
+{{- if .Values.sbc.rtp.extraVolumes }}
+{{ toYaml .Values.sbc.rtp.extraVolumes | default "" | nindent 8 }}
+{{- end }}
       initContainers:
         - image: kanisterio/mysql-sidecar:0.40.0
           name: db-create-wait
@@ -45,6 +49,9 @@ spec:
                 secretKeyRef:
                   name: jambonz-secrets
                   key: MYSQL_PASSWORD
+{{- if .Values.sbc.rtp.extraInitContainers }}
+{{ toYaml .Values.sbc.rtp.extraInitContainers | default "" | nindent 8 }}
+{{- end }}
       containers:
         - name: rtpengine-sidecar
           image: {{ .Values.rtpengine.sidecarImage }}
@@ -101,6 +108,9 @@ spec:
           ports:
             - containerPort: 22222
               protocol: TCP
+{{- if .Values.sbc.rtp.extraContainers }}
+{{ toYaml .Values.sbc.rtp.extraContainers | default "" | nindent 8 }}
+{{- end }}
       restartPolicy: Always
   {{- if .Values.global.recordings.enabled }}
   volumeClaimTemplates:

--- a/templates/sbc-rtp-statefulset.yaml
+++ b/templates/sbc-rtp-statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if not .Values.sbc.rtp.statefulset.enabled }}
+{{- if .Values.sbc.rtp.statefulset.enabled }}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   namespace: {{ .Release.Namespace | quote }}
   name: jambonz-sbc-rtp
@@ -10,6 +10,8 @@ metadata:
   annotations:
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
 spec:
+  serviceName: jambonz-sbc-rtp
+  replicas: {{ .Values.sbc.rtp.statefulset.replicas }}
   selector:
     matchLabels:
       app: jambonz-sbc-rtp
@@ -99,11 +101,15 @@ spec:
           ports:
             - containerPort: 22222
               protocol: TCP
-      {{- if .Values.global.recordings.enabled }}
-      volumes:
-      - name: recordings
-        persistentVolumeClaim:
-          claimName: {{ .Values.rtpengine.recordings.pvc | quote }}
-      {{- end }}
       restartPolicy: Always
+  {{- if .Values.global.recordings.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: recordings
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: {{ .Values.rtpengine.recordings.storage }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -59,7 +59,12 @@ sbc:
       label: voip-environment 
       value: rtp
     toleration: rtp
-    
+    # enable it only if the recordings are also enabled
+    statefulset:
+      enabled: false
+      # match this value with the number of jambonz-rtp daemonsets/nodes
+      replicas: 1
+
 # information used by the Node.js apps to write statsd to a telegraf listening instance
 stats: 
   enabled: "1"
@@ -83,6 +88,7 @@ rtpengine:
     pvc: recordings-shared-volume
     dir: /recordings
     method: pcap
+    storage: 10Gi
 
 # used by sidecar apps in sbc-sip and feature-server to connect locally to drachtio server
 drachtio: 
@@ -107,6 +113,7 @@ mysql:
   host: mysql 
   database: jambones
   user: jambones 
+  # used when the rtp is in StatefulSet mode (sbc.rtp.statefulset.enabled is true)
   storage: 10Gi
 
 # redis configuration used by Node.js app that need to connect

--- a/values.yaml
+++ b/values.yaml
@@ -59,10 +59,16 @@ sbc:
       label: voip-environment 
       value: rtp
     toleration: rtp
-    # enable it only if the recordings are also enabled
+    # list of extra initContainers
+    extraInitContainers:
+    # list of extra containers/sidecars
+    extraContainers:
+    # list of extra volumes
+    extraVolumes:
     statefulset:
+      # enable it only if the recordings are also enabled
       enabled: false
-      # match this value with the number of jambonz-rtp daemonsets/nodes
+      # match this value with the number of jambonz-rtp nodes
       replicas: 1
 
 # information used by the Node.js apps to write statsd to a telegraf listening instance


### PR DESCRIPTION
With these changes, it will be possible to:

- Change the SBC-RTP deployment from a DaemonSet to a StatefulSet
- Add extra fields to the SBC-RTP base yaml such as containers, initContainers, and volumes.

It is useful for using the call recording feature, like sharing the recordings volume.