### PR TITLE
Added support for setting the service account to SBC-RTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ helm uninstall -n <namespace> <release-name>
 |sbc.rtp.nodeSelector.label|label name used to select sip node pool|"voip-environment"|
 |sbc.rtp.nodeSelector.value|label value used to select sip node pool|"rtp"|
 |sbc.rtp.toleration|taint assigned to sip node pool|"rtp"|
+|sbc.rtp.serviceAccountName|service account name to be used|""|
 |sbc.rtp.extraInitContainers|list of initContainers to add to the sbc-rtp definition of initContainers||
 |sbc.rtp.extraContainers|list of sidecars to add to the sbc-rtp definition of containers||
 |sbc.rtp.extraVolumes|list of volumes to add to the sbc-rtp definition of volumes||

--- a/templates/sbc-rtp-daemonset.yaml
+++ b/templates/sbc-rtp-daemonset.yaml
@@ -26,6 +26,9 @@ spec:
         - key: {{ .Values.sbc.rtp.toleration | quote }}
           operator: "Exists"
           effect: "NoSchedule"
+{{- if .Values.sbc.rtp.serviceAccountName }}
+      serviceAccountName: {{ .Values.sbc.rtp.serviceAccountName | quote }}
+{{- end }}
       volumes:
 {{- if .Values.sbc.rtp.extraVolumes }}
 {{ toYaml .Values.sbc.rtp.extraVolumes | default "" | nindent 8 }}

--- a/templates/sbc-rtp-statefulset.yaml
+++ b/templates/sbc-rtp-statefulset.yaml
@@ -28,6 +28,9 @@ spec:
         - key: {{ .Values.sbc.rtp.toleration | quote }}
           operator: "Exists"
           effect: "NoSchedule"
+{{- if .Values.sbc.rtp.serviceAccountName }}
+      serviceAccountName: {{ .Values.sbc.rtp.serviceAccountName | quote }}
+{{- end }}
       volumes:
 {{- if .Values.sbc.rtp.extraVolumes }}
 {{ toYaml .Values.sbc.rtp.extraVolumes | default "" | nindent 8 }}


### PR DESCRIPTION
With the default settings, the SBC-RTP deployment will have the `serviceAccountName` as `default`. With this PR, it will be possible to change it to another value.