### PR TITLE
Added the Root Password option to the db chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: jambonz
-version: 0.1.30
+version: 0.1.31
 appVersion: 0.8.4
 description: open source CPaaS for communication service providers
 dependencies: 
   - name: db 
-    version: 0.1.4
+    version: 0.1.5
     condition: db.enabled
   - name: monitoring 
     version: 0.1.5

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ helm uninstall -n <namespace> <release-name>
 |mysql.database|jambonz database|"jambones"|
 |mysql.user|mysql user|"jambones"|
 |mysql.storage|amount of storage to allocate for mysql database|"10Gi"|
+|mysql.rootSecret|if set, use it for the root password||
 |redis.image|redis image|redis:alpine|
 |redis.host|redis service name|"redis"|
 |redis.port|redis listening port|"6379"|

--- a/charts/db/Chart.yaml
+++ b/charts/db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: db
-version: 0.1.4
+version: 0.1.5
 description: database elements (mysql+redis) for a jambonz CPaaS system
 home: https://jambonz.org
 keywords:

--- a/charts/db/templates/mysql-statefulset.yaml
+++ b/charts/db/templates/mysql-statefulset.yaml
@@ -28,8 +28,21 @@ spec:
           args:
             - "--ignore-db-dir=lost+found"
           env:
+            {{- if .Values.mysql.rootSecret }}
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: secrets
+                  key: MYSQL_ROOT_PASSWORD
+            - name: MYSQL_PWD # For healthcheck
+              valueFrom:
+                secretKeyRef:
+                  name: secrets
+                  key: MYSQL_ROOT_PASSWORD
+            {{- else }}
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "yes"
+            {{- end }}
             - name: MYSQL_DATABASE
               value: {{ .Values.mysql.database }}
             - name: MYSQL_PASSWORD

--- a/charts/db/templates/secrets.yaml
+++ b/charts/db/templates/secrets.yaml
@@ -9,3 +9,6 @@ type: Opaque
 data:
     # use 32 bytes of random value, hex
     MYSQL_PASSWORD: {{ .Values.mysql.secret }}
+    {{- if .Values.mysql.rootSecret }}
+    MYSQL_ROOT_PASSWORD: {{ .Values.mysql.rootSecret}}
+    {{- end }}

--- a/charts/db/values.yaml
+++ b/charts/db/values.yaml
@@ -5,6 +5,8 @@ mysql:
   database: jambones
   user: jambones 
   storage: 10Gi
+  # if empty, an empty password is used for the root user using MYSQL_ALLOW_EMPTY_PASSWORD
+  rootSecret:
   secret: amFtYm9uZXM=
 # redis configuration used by Node.js app that need to connect
 redis: 

--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -80,7 +80,7 @@ spec:
           imagePullPolicy: {{ default "IfNotPresent" .Values.freeswitch.imagePullPolicy }}
           args:
           {{- range .Values.freeswitch.args }}
-            - {{ . }}
+            - {{ . | quote }}
           {{- end }}
           env: 
             - name: MOD_AUDIO_FORK_SUBPROTOCOL_NAME


### PR DESCRIPTION
With this change it will be possible to setup a root password in order to the database to not be exposed.



Also, quote the freeswitch args because we may pass the ports like so:

``` yml
freeswitch: 
  image: drachtio/drachtio-freeswitch-mrf:0.4.21
  imagePullPolicy: IfNotPresent
  args:
    - freeswitch
    - --codec-answer-generous
    - --rtp-range-start
    - 15000
    - --rtp-range-end
    - 19000
```

and the ports were being parsed to number (_Cannot unmarshal number into Go value of type string_) even using `"15000"`