### PR TITLE
Added support for global and specific pod annotations

### DIFF
--- a/charts/db/templates/db-create.yaml
+++ b/charts/db/templates/db-create.yaml
@@ -11,6 +11,12 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.mysql.podAnnotations }}
+        {{ toYaml .Values.mysql.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: db 

--- a/charts/db/templates/mysql-statefulset.yaml
+++ b/charts/db/templates/mysql-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
       name: mysql
       labels:
         app: mysql
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.mysql.podAnnotations }}
+        {{ toYaml .Values.mysql.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/db/templates/redis-statefulset.yaml
+++ b/charts/db/templates/redis-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
       name: redis
       labels:
         app: redis
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.redis.podAnnotations }}
+        {{ toYaml .Values.redis.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/db/values.yaml
+++ b/charts/db/values.yaml
@@ -8,11 +8,14 @@ mysql:
   # if empty, an empty password is used for the root user using MYSQL_ALLOW_EMPTY_PASSWORD
   rootSecret:
   secret: amFtYm9uZXM=
+  podAnnotations:
+
 # redis configuration used by Node.js app that need to connect
 redis: 
   image: redis:alpine
   host: redis 
   port: "6379"
+  podAnnotations:
 
 # Storage Class definition for the StatefulSet
 storageClassName:

--- a/charts/monitoring/templates/cassandra-init-job.yaml
+++ b/charts/monitoring/templates/cassandra-init-job.yaml
@@ -6,6 +6,15 @@ metadata:
 spec:
   template:
     spec:
+      template:
+        metadata:
+          annotations:
+            {{- if .Values.global.podAnnotations }}
+            {{ toYaml .Values.global.podAnnotations | default "" | nindent 12 }}
+            {{- end }}
+            {{- if .Values.cassandra.podAnnotations }}
+            {{ toYaml .Values.cassandra.podAnnotations | default "" | nindent 12 }}
+            {{- end }}
       restartPolicy: OnFailure
       containers:
       - name: cassandra-init-job

--- a/charts/monitoring/templates/cassandra-statefulset.yaml
+++ b/charts/monitoring/templates/cassandra-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
     metadata:
       labels:
         app: cassandra
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.cassandra.podAnnotations }}
+        {{ toYaml .Values.cassandra.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/templates/grafana-statefulset.yaml
+++ b/charts/monitoring/templates/grafana-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
       name: grafana
       labels:
         app: grafana
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.grafana.podAnnotations }}
+        {{ toYaml .Values.grafana.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/templates/heplify-server-statefulset.yaml
+++ b/charts/monitoring/templates/heplify-server-statefulset.yaml
@@ -16,6 +16,13 @@ spec:
     metadata:
       labels:
         app: heplify-server
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.heplifyServer.podAnnotations }}
+        {{ toYaml .Values.heplifyServer.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/templates/influxdb-statefulset.yaml
+++ b/charts/monitoring/templates/influxdb-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
       name: influxdb
       labels:
         app: influxdb
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.influxdb.podAnnotations }}
+        {{ toYaml .Values.influxdb.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/templates/jaeger-collector-deployment.yaml
+++ b/charts/monitoring/templates/jaeger-collector-deployment.yaml
@@ -16,6 +16,13 @@ spec:
     metadata:
       labels:
         app: jaeger-collector
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.jaegerCollector.podAnnotations }}
+        {{ toYaml .Values.jaegerCollector.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: jaeger-collector

--- a/charts/monitoring/templates/jaeger-query-deployment.yaml
+++ b/charts/monitoring/templates/jaeger-query-deployment.yaml
@@ -16,6 +16,13 @@ spec:
     metadata:
       labels:
         app: jaeger-query
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.jaegerQuery.podAnnotations }}
+        {{ toYaml .Values.jaegerQuery.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: jaeger-query

--- a/charts/monitoring/templates/jaeger-statefulset.yaml
+++ b/charts/monitoring/templates/jaeger-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
     metadata:
       labels:
         app: jaeger
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.jaeger.podAnnotations }}
+        {{ toYaml .Values.jaeger.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/templates/postgres-statefulset.yaml
+++ b/charts/monitoring/templates/postgres-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
       name: postgres
       labels:
         app: postgres
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.postgres.podAnnotations }}
+        {{ toYaml .Values.postgres.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/templates/telegraf-statefulset.yaml
+++ b/charts/monitoring/templates/telegraf-statefulset.yaml
@@ -17,6 +17,13 @@ spec:
       name: telegraf
       labels:
         app: telegraf
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.telegraf.podAnnotations }}
+        {{ toYaml .Values.telegraf.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/templates/webapp-deployment.yaml
+++ b/charts/monitoring/templates/webapp-deployment.yaml
@@ -15,6 +15,13 @@ spec:
     metadata:
       labels:
         app: homer-webapp
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.homer.podAnnotations }}
+        {{ toYaml .Values.homer.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -2,33 +2,43 @@ grafana:
   image: grafana/grafana-oss:8.4.3 
   hostname:
   storage: 2Gi
+  podAnnotations:
 heplifyServer: 
   image: sipcapture/heplify-server:latest
+  podAnnotations:
 influxdb: 
   image: influxdb:1.8
   loglevel: info
   storage: 20Gi
+  podAnnotations:
 cassandra:
   image: cassandra:3.11
   keyspace: jaeger_v1_dc1
   storage: 10Gi
+  podAnnotations:
 homer: 
   image: sipcapture/webapp:latest
   hostname:
+  podAnnotations:
 postgres: 
   image: postgres:11-alpine
   user: cm9vdA==
   secret: aG9tZXJTZXZlbg==
   storage: 30Gi 
+  podAnnotations:
 telegraf: 
   image: telegraf:1.19
+  podAnnotations:
 jaeger: 
   image: jaegertracing/all-in-one:1.32
   hostname: 
+  podAnnotations:
 jaegerCollector:
   image: jaegertracing/jaeger-collector:1.46
+  podAnnotations:
 jaegerQuery:
   image: jaegertracing/jaeger-query:1.46
+  podAnnotations:
 
 # Storage Class definition for the Stateful Sets
 storageClassName:

--- a/templates/api-server-deployment.yaml
+++ b/templates/api-server-deployment.yaml
@@ -15,6 +15,13 @@ spec:
     metadata:
       labels:
         app: api-server
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.api.podAnnotations }}
+        {{ toYaml .Values.api.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/apiban-cronjob.yaml
+++ b/templates/apiban-cronjob.yaml
@@ -8,6 +8,14 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- if .Values.global.podAnnotations }}
+            {{ toYaml .Values.global.podAnnotations | default "" | nindent 12 }}
+            {{- end }}
+            {{- if .Values.apiban.podAnnotations }}
+            {{ toYaml .Values.apiban.podAnnotations | default "" | nindent 12 }}
+            {{- end }}
         spec:
           {{- if .Values.global.affinity }}
           affinity:

--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -17,6 +17,13 @@ spec:
     metadata:
       labels:
         app: feature-server
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.featureServer.podAnnotations }}
+        {{ .Values.featureServer.podAnnotations | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/sbc-call-router-deployment.yaml
+++ b/templates/sbc-call-router-deployment.yaml
@@ -15,6 +15,13 @@ spec:
     metadata:
       labels:
         app: sbc-call-router
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.sbcCallRouter.podAnnotations }}
+        {{ toYaml .Values.sbcCallRouter.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/sbc-inbound-deployment.yaml
+++ b/templates/sbc-inbound-deployment.yaml
@@ -15,6 +15,13 @@ spec:
     metadata:
       labels:
         app: sbc-inbound
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.sbcInbound.podAnnotations }}
+        {{ toYaml .Values.sbcInbound.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/sbc-outbound-deployment.yaml
+++ b/templates/sbc-outbound-deployment.yaml
@@ -15,6 +15,13 @@ spec:
     metadata:
       labels:
         app: sbc-outbound
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.sbcOutbound.podAnnotations }}
+        {{ toYaml .Values.sbcOutbound.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/sbc-rtp-daemonset.yaml
+++ b/templates/sbc-rtp-daemonset.yaml
@@ -17,6 +17,13 @@ spec:
     metadata:
       labels:
         app: jambonz-sbc-rtp
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.sbc.rtp.podAnnotations }}
+        {{ toYaml .Values.sbc.rtp.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/sbc-rtp-statefulset.yaml
+++ b/templates/sbc-rtp-statefulset.yaml
@@ -19,6 +19,13 @@ spec:
     metadata:
       labels:
         app: jambonz-sbc-rtp
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.sbc.rtp.podAnnotations }}
+        {{ toYaml .Values.sbc.rtp.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/sbc-sip-daemonset.yaml
+++ b/templates/sbc-sip-daemonset.yaml
@@ -14,6 +14,13 @@ spec:
     metadata:
       labels:
         app: jambonz-sbc-sip
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.sbc.sip.podAnnotations }}
+        {{ toYaml .Values.sbc.sip.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/templates/webapp-deployment.yaml
+++ b/templates/webapp-deployment.yaml
@@ -15,6 +15,13 @@ spec:
     metadata:
       labels:
         app: webapp
+      annotations:
+        {{- if .Values.global.podAnnotations }}
+        {{ toYaml .Values.global.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
+        {{- if .Values.webapp.podAnnotations }}
+        {{ toYaml .Values.webapp.podAnnotations | default "" | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.global.affinity }}
       affinity:

--- a/values.yaml
+++ b/values.yaml
@@ -22,6 +22,7 @@ global:
     accountCalls: "0"
     appCalls: "0"
   affinity:
+  podAnnotations:
     
 db: 
   # if true, create the db subchart
@@ -62,6 +63,7 @@ sbc:
       label: voip-environment 
       value: sip
     toleration: sip
+    podAnnotations:
     ssl:
       enabled: false
   rtp: 
@@ -69,6 +71,7 @@ sbc:
       label: voip-environment 
       value: rtp
     toleration: rtp
+    podAnnotations:
     storageClassName:
     # list of extra initContainers
     extraInitContainers:
@@ -132,12 +135,14 @@ mysql:
   user: jambones 
   # used when the rtp is in StatefulSet mode (sbc.rtp.statefulset.enabled is true)
   storage: 10Gi
+  podAnnotations:
 
 # redis configuration used by Node.js app that need to connect
 redis: 
   image: redis:alpine
   host: redis 
   port: "6379"
+  podAnnotations:
 
 # configuration for jambonz-api-server
 api: 
@@ -145,6 +150,7 @@ api:
   imagePullPolicy: Always
   httpPort: "3000"
   replicas: 1
+  podAnnotations:
   # (required) hostname for the jambonz port ingress
   hostname:
   # defaults to http, if you have tls enabled change to https 
@@ -156,6 +162,7 @@ webapp:
   image: jambonz/webapp:0.8.4-3
   imagePullPolicy: IfNotPresent
   replicas: 1
+  podAnnotations:
   
   # (required) hostname for the jambonz port ingress
   hostname: 
@@ -174,6 +181,7 @@ sbcInbound:
   imagePullPolicy: IfNotPresent
   drachtioPort: "4000"
   replicas: 1
+  podAnnotations:
 
 # sbc-outbound configuration
 sbcOutbound: 
@@ -181,6 +189,7 @@ sbcOutbound:
   imagePullPolicy: IfNotPresent
   drachtioPort: "4000"
   replicas: 1
+  podAnnotations:
 
 # sbc-sip-sidecar configuration
 sbcSipSidecar:
@@ -204,6 +213,7 @@ featureServer:
   awsRegion: us-west-1
   replicas: 1
   otelSampleRate: 1.0
+  podAnnotations:
 
 # sbc-sip configuration
 sbcSip: 
@@ -220,3 +230,4 @@ apiban:
   redisKey: "apiban:ips"
   refreshInterval: "3600"
   foreverBlockRanges: "128.90.0.0/16,162.142.125.0/24,198.235.24.0/24,205.210.31.0/24"
+  podAnnotations:


### PR DESCRIPTION
This change is helpful for adding a global annotation to all pods (e.g.: enabling a mesh) and then for each workload (e.g.: opening specific ports). By default, none is added to the current deployments.

The values are the following:

``` yml
global:
  podAnnotations:
    anyGlobalAnnotation: allPodsHaveThisOne

featureServer:
  podAnnotations:
    fsAnnotation: onlyFsHasThisOne
```

In this example, featureServer will have both annotations.