### PR TITLE
Added node selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ helm uninstall -n <namespace> <release-name>
 |sbc.rtp.extraVolumes|list of volumes to add to the sbc-rtp definition of volumes||
 |sbc.rtp.statefulset.enabled|use a StatefulSet instead of DaemonSet for the sbc-rtp|`false`|
 |sbc.rtp.statefulset.replicas|number of replicas for the StatefulSet|`1`|
+|sbcCallRouter.nodeSelector.label| optional Node Selector Label for sbc-call-router ||
+|sbcCallRouter.nodeSelector.value| optional Node Selector Value for sbc-call-router ||
+|sbcInbound.nodeSelector.label| optional Node Selector Label for sbc-inbound ||
+|sbcInbound.nodeSelector.value| optional Node Selector Value for sbc-inbound ||
+|sbcOutbound.nodeSelector.label| optional Node Selector Label for sbc-outbound ||
+|sbcOutbound.nodeSelector.value| optional Node Selector Value for sbc-outbound ||
 |stats.enabled|if set, jambonz apps write stats to telegraf|"1"|
 |stats.host|telegraf service name|"telegraf"|
 |stats.port|telegraf service listening port|"8125"|
@@ -284,9 +290,15 @@ helm uninstall -n <namespace> <release-name>
 |api.imagePullPolicy|jambonz-api-server image pull policy|"Always"|
 |api.httpPort|http port to listen on|"3000"|
 |api.hostname|(required) FQDN for api ingress controller|""|
+|api.nodeSelector.label| optional Node Selector Label for api-server ||
+|api.nodeSelector.value| optional Node Selector Value for api-server ||
+|apiban.nodeSelector.label| optional Node Selector Label for apiban ||
+|apiban.nodeSelector.value| optional Node Selector Value for apiban ||
 |webapp.image|jambonz webapp image|jambonz/webapp:latest|
 |webapp.imagePullPolicy|jambonz webapp image pull policy|"Always"|
 |webapp.hostname|(required ) FQDN for webapp ingress controller|""|
+|webapp.nodeSelector.label| optional Node Selector Label for webapp ||
+|webapp.nodeSelector.value| optional Node Selector Value for webapp ||
 |sbcInbound.image|sbc-inbound image|jambonz/sbc-inbound:latest|
 |sbcInbound.imagePullPolicy|sbc-inbound image pull policy|"Always"|
 |sbcOutbound.drachtioPort|port to listen on for outbound connections from drachtio|"4000"|
@@ -301,6 +313,8 @@ helm uninstall -n <namespace> <release-name>
 |featureServer.image|feature-server image|jambonz/feature-server:latest|
 |featureServer.imagePullPolicy|feature-server image pull policy|"Always"|
 |featureServer.httpPort|port to listen on for api requests|"3000"|
+|featureServer.nodeSelector.label| optional Node Selector Label for feature-server ||
+|featureServer.nodeSelector.value| optional Node Selector Value for feature-server ||
 |feature.drachtioConnection|drachtio connection information|"localhost:9022:cymru"|
 |feature.freeswitchConnection|freeswitch connection information|"localhost:8021:JambonzR0ck$"|
 |sbcSip.loglevel|drachtio loglevel in sbc sip container, should be info or debug|"info"|

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ helm uninstall -n <namespace> <release-name>
 |db.enabled|if true, install the db sub-chart|true|
 |db.affinity|set the affinity structure for the db subchart resources||
 |db.storageClassName|set the `storageClassName` for the db subchart StatefulSet resources||
+|db.mysql.nodeSelector.label| optional Node Selector Label for mysql and db-create ||
+|db.mysql.nodeSelector.value| optional Node Selector Value for mysql and db-create ||
+|db.redis.nodeSelector.label| optional Node Selector Label for redis ||
+|db.redis.nodeSelector.value| optional Node Selector Value for redis ||
 |monitoring.enabled|if true, install the monitoring sub-chart|true|
 |monitoring.affinity|set the affinity structure for the monitoring subchart resources||
 |monitoring.storageClassName|set the `storageClassName` for the monitoring subchart StatefulSet resources||

--- a/charts/db/templates/db-create.yaml
+++ b/charts/db/templates/db-create.yaml
@@ -18,6 +18,10 @@ spec:
         {{ toYaml .Values.mysql.podAnnotations | default "" | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.mysql.nodeSelector }}
+      nodeSelector:
+        {{ .Values.mysql.nodeSelector.label }}: {{ .Values.mysql.nodeSelector.value | quote }}      
+      {{- end }}
       containers:
         - name: db 
           image: jambonz/db-create:0.8.4

--- a/charts/db/templates/mysql-statefulset.yaml
+++ b/charts/db/templates/mysql-statefulset.yaml
@@ -29,6 +29,10 @@ spec:
       affinity:
         {{ toYaml .Values.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.mysql.nodeSelector }}
+      nodeSelector:
+        {{ .Values.mysql.nodeSelector.label }}: {{ .Values.mysql.nodeSelector.value | quote }}      
+      {{- end }}
       containers:
         - name: mysql 
           image: {{ .Values.mysql.image }}

--- a/charts/db/templates/redis-statefulset.yaml
+++ b/charts/db/templates/redis-statefulset.yaml
@@ -29,6 +29,10 @@ spec:
       affinity:
         {{ toYaml .Values.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{ .Values.redis.nodeSelector.label }}: {{ .Values.redis.nodeSelector.value | quote }}      
+      {{- end }}
       containers:
         - name: redis 
           image: {{ .Values.redis.image }}

--- a/templates/api-server-deployment.yaml
+++ b/templates/api-server-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       affinity:
         {{ toYaml .Values.global.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.api.nodeSelector }}
+      nodeSelector:
+        {{ .Values.api.nodeSelector.label }}: {{ .Values.api.nodeSelector.value | quote }}      
+      {{- end }}
       initContainers:
         - image: kanisterio/mysql-sidecar:0.40.0
           name: db-create-wait

--- a/templates/apiban-cronjob.yaml
+++ b/templates/apiban-cronjob.yaml
@@ -21,6 +21,10 @@ spec:
           affinity:
             {{ toYaml .Values.global.affinity | default "" | nindent 12 }}
           {{- end }}
+          {{- if .Values.apiban.nodeSelector }}
+          nodeSelector:
+            {{ .Values.apiban.nodeSelector.label }}: {{ .Values.apiban.nodeSelector.value | quote }}      
+          {{- end }}
           containers:
           - name: apiban-redis
             image: jambonz/apiban-redis:latest

--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -29,6 +29,10 @@ spec:
       affinity:
         {{ toYaml .Values.global.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.featureServer.nodeSelector }}
+      nodeSelector:
+        {{ .Values.featureServer.nodeSelector.label }}: {{ .Values.featureServer.nodeSelector.value | quote }}      
+      {{- end }}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/templates/sbc-call-router-deployment.yaml
+++ b/templates/sbc-call-router-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       affinity:
         {{ toYaml .Values.global.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.sbcCallRouter.nodeSelector }}
+      nodeSelector:
+        {{ .Values.sbcCallRouter.nodeSelector.label }}: {{ .Values.sbcCallRouter.nodeSelector.value | quote }}      
+      {{- end }}
       containers:
         - name: sbc-call-router
           image: {{ .Values.sbcCallRouter.image }}

--- a/templates/sbc-inbound-deployment.yaml
+++ b/templates/sbc-inbound-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       affinity:
         {{ toYaml .Values.global.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.sbcInbound.nodeSelector }}
+      nodeSelector:
+        {{ .Values.sbcInbound.nodeSelector.label }}: {{ .Values.sbcInbound.nodeSelector.value | quote }}      
+      {{- end }}   
       containers:
         - name: sbc-inbound
           image: {{ .Values.sbcInbound.image }}

--- a/templates/sbc-outbound-deployment.yaml
+++ b/templates/sbc-outbound-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       affinity:
         {{ toYaml .Values.global.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.sbcOutbound.nodeSelector }}
+      nodeSelector:
+        {{ .Values.sbcOutbound.nodeSelector.label }}: {{ .Values.sbcOutbound.nodeSelector.value | quote }}      
+      {{- end }}    
       containers:
         - name: sbc-outbound
           image: {{ .Values.sbcOutbound.image }}

--- a/templates/webapp-deployment.yaml
+++ b/templates/webapp-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       affinity:
         {{ toYaml .Values.global.affinity | default "" | nindent 8 }}
       {{- end }}
+      {{- if .Values.webapp.nodeSelector }}
+      nodeSelector:
+        {{ .Values.webapp.nodeSelector.label }}: {{ .Values.webapp.nodeSelector.value | quote }}      
+      {{- end }}
       containers:
         - env:
             - name: NODE_ENV


### PR DESCRIPTION
Added node selectors for redis and mysql in the db template. Also for api-server, apiban, feature-server, sbc-inbound, sbc-outbond, call-router and webapp.

These resources now have another option for node pool allocation to complement the affinity and toleration.