### PR TITLE
Control loglevel of drachtio/sofia for the feature-server deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,12 @@ helm uninstall -n <namespace> <release-name>
 |featureServer.httpPort|port to listen on for api requests|"3000"|
 |featureServer.nodeSelector.label| optional Node Selector Label for feature-server ||
 |featureServer.nodeSelector.value| optional Node Selector Value for feature-server ||
+|featureServer.drachtio.loglevel| drachtio loglevel for drachtio container in feature-server deployment, should be info or debug (can also be notice, warning, error) |"info"|
+|featureServer.drachtio.sofiaLoglevel| sofia-sip log level for drachtio container in feature-server deployment, should be 1-9 (can also be 0)|"3"|
 |feature.drachtioConnection|drachtio connection information|"localhost:9022:cymru"|
 |feature.freeswitchConnection|freeswitch connection information|"localhost:8021:JambonzR0ck$"|
-|sbcSip.loglevel|drachtio loglevel in sbc sip container, should be info or debug|"info"|
-|sbcSip.sofiaLogLevel|sofia-sip log level for drachtio in sbc sip container, should be 1-9|"3|
+|sbcSip.loglevel|drachtio loglevel in sbc sip container, should be info or debug (can also be notice, warning, error)|"info"|
+|sbcSip.sofiaLogLevel|sofia-sip log level for drachtio in sbc sip container, should be 1-9 (can also be 0)|"3|
 |dbWaiter.image|image of sidecar mysql client app to use for testing database readiness|d3fk/kubectl:v1.18|
 
 

--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -83,7 +83,7 @@ spec:
                   "-c",
                   "while $(curl --output /dev/null --silent --head --fail-early http://127.0.0.1:3000); do printf '.'; sleep 10; done"
                 ]
-          args: ['drachtio', '--contact', 'sip:*:5060;transport=udp', '--mtu', '4096', '--loglevel', 'info', 'sofia-loglevel', '3']
+          args: ['drachtio', '--contact', 'sip:*:5060;transport=udp', '--mtu', '4096', '--loglevel', {{ .Values.featureServer.drachtio.loglevel | squote }}, 'sofia-loglevel', {{ .Values.featureServer.drachtio.sofiaLoglevel | squote }}]
           ports:
             - containerPort: 9022
         - name: freeswitch

--- a/values.yaml
+++ b/values.yaml
@@ -220,6 +220,9 @@ featureServer:
   replicas: 1
   otelSampleRate: 1.0
   podAnnotations:
+  drachtio:
+    loglevel: info
+    sofiaLoglevel: "3"
 
 # sbc-sip configuration
 sbcSip: 

--- a/values.yaml
+++ b/values.yaml
@@ -107,7 +107,7 @@ rtpengine:
   sidecarImage: jambonz/rtpengine-sidecar:0.8.5
   sidecarImagePullPolicy: Always
   dtmfLogPort:  "22223"
-  loglevel: "7"
+  loglevel: "5"
   homerId: "11"
   # used when global.recordings.enabled is true
   recordings:


### PR DESCRIPTION
## Reasoning and explanation

The drachtio container is producing a decent amount of logs, and in a cloud scenario this results in a higher expense.

This PR adds two new values to control the loglevels of the drachtio container of the feature-server-deployment in the same way as they are controlled in the sbc-sip daemonset.

Default values are still 'info' for drachtio and '3' for sofia.

## Usage examples

### Default values (no input)

```helm template --debug jambonz . --namespace="jambonz" \
  --set "monitoring.homer.hostname=a" \
  --set "monitoring.grafana.hostname=b" \
  --set "monitoring.jaeger.hostname=c" \
  --set "api.hostname=d" --set cloud=gcp \
  -s templates/feature-server-deployment.yaml
```

produces

```
      containers:
        - name: drachtio
          image: drachtio/drachtio-server:0.8.24
          imagePullPolicy: IfNotPresent
          env: 
            - name: CLOUD 
              value: "gcp"
            - name: IMDSv2 
              value: 
            - name: SOFIA_SEARCH_DOMAINS
              value: "1"
            - name: SOFIA_SRES_NO_CACHE
              value: "1"
            - name: DRACHTIO_SECRET
              valueFrom:
                secretKeyRef:
                  name: jambonz-secrets
                  key: DRACHTIO_SECRET
          lifecycle:
            preStop:
              exec:
                command: [
                  "/bin/sh",
                  "-c",
                  "while $(curl --output /dev/null --silent --head --fail-early http://127.0.0.1:3000); do printf '.'; sleep 10; done"
                ]
          args: ['drachtio', '--contact', 'sip:*:5060;transport=udp', '--mtu', '4096', '--loglevel', 'info', 'sofia-loglevel', '3']
          ports:
            - containerPort: 9022
```

### Values passed to the helm command

<pre><code>
helm template --debug jambonz . --namespace="jambonz" \
  --set "monitoring.homer.hostname=a" \
  --set "monitoring.grafana.hostname=b" \
  --set "monitoring.jaeger.hostname=c" \
  --set "api.hostname=d" --set cloud=gcp \
  <b>--set "featureServer.drachtio.loglevel=warning" \
  --set "featureServer.drachtio.sofiaLoglevel=6"</b> \
  -s templates/feature-server-deployment.yaml
</code></pre>

produces

````
      containers:
        - name: drachtio
          image: drachtio/drachtio-server:0.8.24
          imagePullPolicy: IfNotPresent
          env: 
            - name: CLOUD 
              value: "gcp"
            - name: IMDSv2 
              value: 
            - name: SOFIA_SEARCH_DOMAINS
              value: "1"
            - name: SOFIA_SRES_NO_CACHE
              value: "1"
            - name: DRACHTIO_SECRET
              valueFrom:
                secretKeyRef:
                  name: jambonz-secrets
                  key: DRACHTIO_SECRET
          lifecycle:
            preStop:
              exec:
                command: [
                  "/bin/sh",
                  "-c",
                  "while $(curl --output /dev/null --silent --head --fail-early http://127.0.0.1:3000); do printf '.'; sleep 10; done"
                ]
          args: ['drachtio', '--contact', 'sip:*:5060;transport=udp', '--mtu', '4096', '--loglevel', 'warning', 'sofia-loglevel', '6']
          ports:
            - containerPort: 9022