### PR TITLE
Control loglevel, min/default expires interval of sbc-sip-sidecar via helm chart values

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,12 @@ helm uninstall -n <namespace> <release-name>
 |featureServer.httpPort|port to listen on for api requests|"3000"|
 |featureServer.nodeSelector.label| optional Node Selector Label for feature-server ||
 |featureServer.nodeSelector.value| optional Node Selector Value for feature-server ||
+|featureServer.drachtio.loglevel| drachtio loglevel for drachtio container in feature-server deployment, should be info or debug (can also be notice, warning, error) |"info"|
+|featureServer.drachtio.sofiaLoglevel| sofia-sip log level for drachtio container in feature-server deployment, should be 1-9 (can also be 0)|"3"|
 |feature.drachtioConnection|drachtio connection information|"localhost:9022:cymru"|
 |feature.freeswitchConnection|freeswitch connection information|"localhost:8021:JambonzR0ck$"|
-|sbcSip.loglevel|drachtio loglevel in sbc sip container, should be info or debug|"info"|
-|sbcSip.sofiaLogLevel|sofia-sip log level for drachtio in sbc sip container, should be 1-9|"3|
+|sbcSip.loglevel|drachtio loglevel in sbc sip container, should be info or debug (can also be notice, warning, error)|"info"|
+|sbcSip.sofiaLogLevel|sofia-sip log level for drachtio in sbc sip container, should be 1-9 (can also be 0)|"3|
 |dbWaiter.image|image of sidecar mysql client app to use for testing database readiness|d3fk/kubectl:v1.18|
 
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ helm uninstall -n <namespace> <release-name>
 |sbcOutbound.drachtioPort|port to listen on for outbound connections from drachtio|"4000"|
 |sbcSipSidecar.image|sbc-sip-sidecar image|jambonz/sbc-sip-sidecar:latest|
 |sbcSipSidecar.imagePullPolicy|sbc-sip-sidecar image pull policy|"Always"|
+|sbcSipSidecar.loglevel|sbc-sip-sidecar log level |"info"|
+|sbcSipSidecar.outboundRegister.minExpiresInterval| minimum expires interval for outbound registrations (in seconds) | 30|
+|sbcSipSidecar.outboundRegister.defaultExpiresInterval| default expires interval for outbound registrations (in seconds). Will be applied if the server does not provide its own expire data, or if the data provided is smaller than the minimum expires interval | 3600 |
 |sbcCallRouter.image|sbc-call-router image|jambonz/sbc-call-router:latest|
 |sbcCallRouter.imagePullPolicy|sbc-call-router image pull policy|"Always"|
 |sbcCallRouter.drachtioPort|port to listen on for http connections from drachtio|"3000"|

--- a/templates/feature-server-deployment.yaml
+++ b/templates/feature-server-deployment.yaml
@@ -83,7 +83,7 @@ spec:
                   "-c",
                   "while $(curl --output /dev/null --silent --head --fail-early http://127.0.0.1:3000); do printf '.'; sleep 10; done"
                 ]
-          args: ['drachtio', '--contact', 'sip:*:5060;transport=udp', '--mtu', '4096', '--loglevel', 'info', 'sofia-loglevel', '3']
+          args: ['drachtio', '--contact', 'sip:*:5060;transport=udp', '--mtu', '4096', '--loglevel', {{ .Values.featureServer.drachtio.loglevel | squote }}, 'sofia-loglevel', {{ .Values.featureServer.drachtio.sofiaLoglevel | squote }}]
           ports:
             - containerPort: 9022
         - name: freeswitch

--- a/templates/sbc-sip-daemonset.yaml
+++ b/templates/sbc-sip-daemonset.yaml
@@ -131,7 +131,7 @@ spec:
             - name: JAMBONES_REGBOT_CONTACT_USE_IP
               value: "1"
             - name: JAMBONES_LOGLEVEL
-              value: info
+              value: {{ .Values.sbcSipSidecar.loglevel }}
             - name: JAMBONES_REDIS_HOST
               value: redis.{{ default .Release.Namespace .Values.global.db.namespace }}
             - name: JAMBONES_REDIS_PORT
@@ -190,6 +190,10 @@ spec:
                 secretKeyRef:
                   name: jambonz-secrets
                   key: JWT_SECRET
+            - name: JAMBONES_REGBOT_MIN_EXPIRES_INTERVAL
+              value: {{ .Values.sbcSipSidecar.outboundRegister.minExpiresInterval | quote }}
+            - name: JAMBONES_REGBOT_DEFAULT_EXPIRES_INTERVAL
+              value: {{ .Values.sbcSipSidecar.outboundRegister.defaultExpiresInterval | quote }}
         - name: smpp
           image: {{ .Values.smpp.image }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.smpp.imagePullPolicy }} 

--- a/values.yaml
+++ b/values.yaml
@@ -220,6 +220,9 @@ featureServer:
   replicas: 1
   otelSampleRate: 1.0
   podAnnotations:
+  drachtio:
+    loglevel: info
+    sofiaLoglevel: "3"
 
 # sbc-sip configuration
 sbcSip: 

--- a/values.yaml
+++ b/values.yaml
@@ -201,6 +201,10 @@ sbcOutbound:
 sbcSipSidecar:
   image: jambonz/sbc-sip-sidecar:0.8.5
   imagePullPolicy: IfNotPresent
+  loglevel: info
+  outboundRegister:
+    minExpiresInterval: 30
+    defaultExpiresInterval: 3600
 
 # sbc-call-router configuration
 sbcCallRouter: 

--- a/values.yaml
+++ b/values.yaml
@@ -107,7 +107,7 @@ rtpengine:
   sidecarImage: jambonz/rtpengine-sidecar:0.8.5
   sidecarImagePullPolicy: Always
   dtmfLogPort:  "22223"
-  loglevel: "7"
+  loglevel: "5"
   homerId: "11"
   # used when global.recordings.enabled is true
   recordings:


### PR DESCRIPTION
This PR is related to

https://github.com/jambonz/sbc-sip-sidecar/pull/50

and adds three new values in the helm chart to control the newly added two envvars of sbc-sip-sidecar as well as exposing the loglevel configuration of the same container.